### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git clone --depth 1 https://github.com/tinloof/medusa-b2c-starter
 
 2. Install dependencies:
 
-This project utilizes pnpm for package management and monorepo functionality. To install dependencies using pnpm, execute the following command:
+This project utilizes [pnpm](https://pnpm.io/installation) for package management and monorepo functionality. To install dependencies using pnpm, execute the following command:
 
 ```
 pnpm install


### PR DESCRIPTION
Hey there, I while in the middle of my due diligence before applying to the Solutions Engineer role, I noticed that new users need to use a search engine to find pnpm installation instructions.  Not a huge change, but given the use and misuse of AI and sponsored results, users might end up in weird corners of the web. Why not help them with a quick link to pnpm's installation page? :)